### PR TITLE
Make tutorial compatible with macOS

### DIFF
--- a/1_lieutenant_on_minikube.sh
+++ b/1_lieutenant_on_minikube.sh
@@ -42,7 +42,7 @@ kubectl -n lieutenant expose deployment lieutenant-api --type=NodePort --port=80
 
 echo "===> Launch ngrok in the background tunneling towards the Lieutenant API"
 setsid ./ngrok.sh >/dev/null 2>&1 < /dev/null &
-sleep 2s
+sleep 2
 
 echo "===> Find external Lieutenant URL through the ngrok API"
 LIEUTENANT_URL=$(curl http://localhost:4040/api/tunnels --silent | jq -r '.["tunnels"][0]["public_url"]')

--- a/5_delete.sh
+++ b/5_delete.sh
@@ -18,7 +18,7 @@ echo "===> Removing tenant"
 kubectl --context minikube -n lieutenant delete tenant "$TENANT_ID"
 
 echo "===> Waiting 20 seconds for the removal of GitLab repositories"
-sleep 20s
+sleep 20
 
 minikube delete
 k3d cluster delete projectsyn

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -17,7 +17,7 @@ wait_for_lieutenant() {
     while [ "$RESULT" != "$EXPECTED" ]
     do
         echo "===> Not yet OK"
-        sleep 5s
+        sleep 5
         RESULT=$($COMMAND)
     done
     echo "===> OK"
@@ -31,7 +31,7 @@ wait_for_token () {
     while [ "$RESULT" != "$EXPECTED" ]
     do
         echo "===> Not yet OK"
-        sleep 10s
+        sleep 10
         RESULT=$($COMMAND)
     done
     echo "===> Bootstrap token OK"

--- a/lib/k3s.sh
+++ b/lib/k3s.sh
@@ -6,7 +6,7 @@ wait_for_k3s () {
     while [ -z "$K3S_RUNNING" ]
     do
         echo "===> K3s not yet ready"
-        sleep 5s
+        sleep 5
         K3S_RUNNING=$(kubectl get nodes | grep k3d)
     done
     echo "===> K3s running"
@@ -19,7 +19,7 @@ wait_for_traefik () {
     while [ -z "$TRAEFIK" ]
     do
         echo "===> Traefik not yet ready"
-        sleep 5s
+        sleep 5
         TRAEFIK=$(kubectl --context k3d-projectsyn get pod -n kube-system | grep traefik | grep Running | grep 1/1)
     done
     echo "===> Traefik ready"


### PR DESCRIPTION
The builtin `sleep` binary on macOS only accepts numerical values (e.g.
10) and can't process an argument like `10s`. For GNU sleep both
variants work.
